### PR TITLE
Fix global state update to limit data to last 24h

### DIFF
--- a/backend/app/background_job/global_state_update.py
+++ b/backend/app/background_job/global_state_update.py
@@ -1,7 +1,8 @@
 def update_top_stocks(db_client, start_date, end_date):
     global_stocks = {}
 
-    all_stocks = db_client.find_all('top-stocks', {})
+    K = 24*2
+    all_stocks = db_client.find_k_of('top-stocks', {}, K, sort_by="end_date", ascending=False)
 
     # Calculate all stock mentions
     for stocks in all_stocks:
@@ -22,7 +23,8 @@ def update_top_stocks(db_client, start_date, end_date):
 def update_top_emojis(db_client, start_date, end_date):
     global_emojis = {}
 
-    all_emojis = db_client.find_all('top-emojis', {})
+    K = 24*2
+    all_emojis = db_client.find_k_of('top-emojis', {}, K, sort_by="end_date", ascending=False)
 
     # Calculate all emoji mentions
     for emojis in all_emojis:
@@ -41,7 +43,8 @@ def update_top_emojis(db_client, start_date, end_date):
 
 
 def update_total_stats(db_client, start_date, end_date):
-    all_stats = db_client.find_all('statistics', {})
+    K = 24*2
+    all_stats = db_client.find_k_of('statistics', {}, K, sort_by="end_date", ascending=False)
 
     total_posts = 0
     total_comments = 0
@@ -98,7 +101,8 @@ def update_total_stats(db_client, start_date, end_date):
 
 
 def update_top_stocks_historic(db_client, start_date, end_date):
-    top_stocks = db_client.find_all('top-stocks', {})
+    K = 24*2
+    top_stocks = db_client.find_k_of('top-stocks', {}, K, sort_by="end_date", ascending=False)
     
     # Get all mentioned stocks and all possible updates
     all_updates = []

--- a/backend/app/background_job/global_state_update.py
+++ b/backend/app/background_job/global_state_update.py
@@ -2,7 +2,7 @@ def update_top_stocks(db_client, start_date, end_date):
     global_stocks = {}
 
     K = 24*2
-    all_stocks = db_client.find_k_of('top-stocks', {}, K, sort_by="end_date", ascending=False)
+    all_stocks = db_client.find_k_of('top-stocks', {}, sort_by="end_date", k=K, ascending=False)
 
     # Calculate all stock mentions
     for stocks in all_stocks:
@@ -24,7 +24,7 @@ def update_top_emojis(db_client, start_date, end_date):
     global_emojis = {}
 
     K = 24*2
-    all_emojis = db_client.find_k_of('top-emojis', {}, K, sort_by="end_date", ascending=False)
+    all_emojis = db_client.find_k_of('top-emojis', {}, sort_by="end_date", k=K, ascending=False)
 
     # Calculate all emoji mentions
     for emojis in all_emojis:
@@ -44,7 +44,7 @@ def update_top_emojis(db_client, start_date, end_date):
 
 def update_total_stats(db_client, start_date, end_date):
     K = 24*2
-    all_stats = db_client.find_k_of('statistics', {}, K, sort_by="end_date", ascending=False)
+    all_stats = db_client.find_k_of('statistics', {}, sort_by="end_date", k=K, ascending=False)
 
     total_posts = 0
     total_comments = 0
@@ -102,7 +102,7 @@ def update_total_stats(db_client, start_date, end_date):
 
 def update_top_stocks_historic(db_client, start_date, end_date):
     K = 24*2
-    top_stocks = db_client.find_k_of('top-stocks', {}, K, sort_by="end_date", ascending=False)
+    top_stocks = db_client.find_k_of('top-stocks', {}, sort_by="end_date", k=K, ascending=False)
     
     # Get all mentioned stocks and all possible updates
     all_updates = []

--- a/backend/app/mongo_client.py
+++ b/backend/app/mongo_client.py
@@ -32,6 +32,17 @@ class MongoPostRepository(object):
         
         return results
 
+    def find_k_of(self, collection, selector, k, sort_by, ascending=True):
+        results = []
+
+        order = 1 if ascending else -1 
+
+        cursor = self.db[collection].find(selector).sort({sort_by: order}).limit(k)
+        for item in cursor:
+            item['_id'] = str(item['_id'])
+            results.append(item)
+        
+        return results
 
     def find(self, collection, selector):
         return self.db[collection].find_one(selector)

--- a/backend/app/mongo_client.py
+++ b/backend/app/mongo_client.py
@@ -32,7 +32,7 @@ class MongoPostRepository(object):
         
         return results
 
-    def find_k_of(self, collection, selector, k, sort_by, ascending=True):
+    def find_k_of(self, collection, selector, sort_by, k=48, ascending=True):
         results = []
 
         order = 1 if ascending else -1 


### PR DESCRIPTION
- Adds a function `find_k_of(self, collection, selector, k, sort_by, ascending=True)` where `k` is number of scraper jobs done in 24h
- Uses `find_k_of` to fetch data only from the last 24h to update global state, so that global state reflects only stats from last 24h